### PR TITLE
Auto-detect encoding type

### DIFF
--- a/io_midicsv.py
+++ b/io_midicsv.py
@@ -1,9 +1,11 @@
 # midi_tools/io_midicsv.py
+import chardet
 import subprocess
 
 def load_midicsv(path):
     events = []
-    with open(path, "r", newline="", encoding="utf-8") as f:
+    encoding_type = chardet.detect(open(path, "rb").read())["encoding"]
+    with open(path, "r", newline="", encoding=encoding_type) as f:
         for line in f:
             raw = line.rstrip("\n")
             striped = raw.strip()


### PR DESCRIPTION
fixes #1 

When opening midi, if contents are not encoded in utf-8, the app will error out.
This fix uses `chardet` to determine the encoding, then uses the appropriate type when opening.

Compiled and tested working on midi provided in #1, as well as a number of my own affected midi. Current functionality should be unchanged.
This is a simple fix, but I don't know for sure how this project was compiled, so please ensure it works properly for you.